### PR TITLE
Add crypto season CLI using CoinGecko and CoinMarketCap data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# Test
-First Repo
+# Crypto Season App
+
+This repository now contains a small Python CLI app that checks Bitcoin market-cap dominance from **CoinGecko** and **CoinMarketCap**, then classifies the current market as:
+
+- **Bitcoin Season** (BTC dominance >= 55%)
+- **Altcoin Season** (BTC dominance <= 45%)
+- **Transition Season** (between those levels)
+
+## Run
+
+```bash
+python crypto_season.py
+```
+
+JSON output:
+
+```bash
+python crypto_season.py --json
+```
+
+## Tests
+
+```bash
+python -m unittest discover -s tests
+```
+
+## Notes
+
+- The app uses CoinGecko's global endpoint and CoinMarketCap's frontend global-metrics endpoint.
+- CoinMarketCap scraping includes a fallback parser against the homepage if the endpoint format changes.

--- a/crypto_season.py
+++ b/crypto_season.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Determine the current crypto market season from CoinGecko and CoinMarketCap data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+USER_AGENT = "Mozilla/5.0 (compatible; CryptoSeasonBot/1.0)"
+
+
+@dataclass
+class DominanceReading:
+    source: str
+    btc_dominance: float
+    timestamp: str
+
+
+def fetch_text(url: str, timeout: int = 20) -> str:
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(req, timeout=timeout) as response:  # nosec B310: fixed URLs only
+        return response.read().decode("utf-8", "ignore")
+
+
+def fetch_json(url: str, timeout: int = 20) -> Any:
+    return json.loads(fetch_text(url, timeout=timeout))
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def get_coingecko_reading() -> DominanceReading:
+    payload = fetch_json("https://api.coingecko.com/api/v3/global")
+    btc_dominance = float(payload["data"]["market_cap_percentage"]["btc"])
+    return DominanceReading(source="CoinGecko", btc_dominance=btc_dominance, timestamp=now_iso())
+
+
+def get_coinmarketcap_reading() -> DominanceReading:
+    # Endpoint used by coinmarketcap.com frontend at the time of writing.
+    try:
+        payload = fetch_json("https://api.coinmarketcap.com/data-api/v3/global-metrics/quotes/latest")
+        btc_dominance = float(payload["data"]["btcDominance"])
+        return DominanceReading(source="CoinMarketCap", btc_dominance=btc_dominance, timestamp=now_iso())
+    except (KeyError, ValueError, URLError, json.JSONDecodeError):
+        pass
+
+    # Fallback: scrape homepage embedded data.
+    homepage = fetch_text("https://coinmarketcap.com/")
+    match = re.search(r'"btcDominance"\s*:\s*([0-9]+(?:\.[0-9]+)?)', homepage)
+    if not match:
+        raise RuntimeError("Could not find btcDominance in CoinMarketCap response")
+    return DominanceReading(source="CoinMarketCap", btc_dominance=float(match.group(1)), timestamp=now_iso())
+
+
+def classify_season(btc_dominance: float) -> str:
+    if btc_dominance >= 55:
+        return "Bitcoin Season"
+    if btc_dominance <= 45:
+        return "Altcoin Season"
+    return "Transition Season"
+
+
+def build_report(readings: list[DominanceReading]) -> dict[str, Any]:
+    avg_dominance = statistics.mean(r.btc_dominance for r in readings)
+    spread = max(r.btc_dominance for r in readings) - min(r.btc_dominance for r in readings)
+    confidence = "high" if spread <= 1.5 else "medium" if spread <= 3 else "low"
+
+    return {
+        "generated_at": now_iso(),
+        "season": classify_season(avg_dominance),
+        "average_btc_dominance": round(avg_dominance, 2),
+        "source_spread": round(spread, 2),
+        "confidence": confidence,
+        "sources": [
+            {
+                "source": r.source,
+                "btc_dominance": round(r.btc_dominance, 2),
+                "timestamp": r.timestamp,
+            }
+            for r in readings
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect crypto market season from CoinGecko and CoinMarketCap")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON report")
+    args = parser.parse_args()
+
+    try:
+        readings = [get_coingecko_reading(), get_coinmarketcap_reading()]
+        report = build_report(readings)
+    except Exception as exc:  # broad to provide useful CLI failure message
+        print(f"Failed to build crypto season report: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return 0
+
+    print(f"Season: {report['season']}")
+    print(f"Average BTC dominance: {report['average_btc_dominance']}%")
+    print(f"Confidence: {report['confidence']} (spread {report['source_spread']}%)")
+    for source in report["sources"]:
+        print(f"- {source['source']}: {source['btc_dominance']}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_crypto_season.py
+++ b/tests/test_crypto_season.py
@@ -1,0 +1,43 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import crypto_season
+
+
+class CryptoSeasonTests(unittest.TestCase):
+    @patch("crypto_season.fetch_json")
+    def test_get_coingecko_reading(self, mock_fetch_json):
+        mock_fetch_json.return_value = {"data": {"market_cap_percentage": {"btc": 53.12}}}
+        reading = crypto_season.get_coingecko_reading()
+        self.assertEqual(reading.source, "CoinGecko")
+        self.assertAlmostEqual(reading.btc_dominance, 53.12)
+
+    @patch("crypto_season.fetch_json")
+    def test_get_coinmarketcap_reading_primary_endpoint(self, mock_fetch_json):
+        mock_fetch_json.return_value = {"data": {"btcDominance": 54.5}}
+        reading = crypto_season.get_coinmarketcap_reading()
+        self.assertEqual(reading.source, "CoinMarketCap")
+        self.assertAlmostEqual(reading.btc_dominance, 54.5)
+
+    @patch("crypto_season.fetch_text")
+    @patch("crypto_season.fetch_json")
+    def test_get_coinmarketcap_reading_fallback_scrape(self, mock_fetch_json, mock_fetch_text):
+        mock_fetch_json.side_effect = json.JSONDecodeError("err", "doc", 1)
+        mock_fetch_text.return_value = '<html><script>{"btcDominance":49.9}</script></html>'
+        reading = crypto_season.get_coinmarketcap_reading()
+        self.assertAlmostEqual(reading.btc_dominance, 49.9)
+
+    def test_build_report(self):
+        readings = [
+            crypto_season.DominanceReading("CoinGecko", 52.0, "t1"),
+            crypto_season.DominanceReading("CoinMarketCap", 50.0, "t2"),
+        ]
+        report = crypto_season.build_report(readings)
+        self.assertEqual(report["season"], "Transition Season")
+        self.assertEqual(report["average_btc_dominance"], 51.0)
+        self.assertEqual(report["confidence"], "medium")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small CLI to determine the current crypto market "season" by measuring Bitcoin market-cap dominance from public data sources and classifying the market as Bitcoin/Altcoin/Transition season. 
- Make the tool resilient to API differences by preferring a frontend metrics endpoint and falling back to homepage scraping when needed.

### Description
- Add `crypto_season.py`, a Python CLI that implements `fetch_text`, `fetch_json`, `get_coingecko_reading`, `get_coinmarketcap_reading` (primary endpoint + fallback scrape), `classify_season`, `build_report`, and a `--json` output mode. 
- Include a `DominanceReading` dataclass and simple confidence scoring based on source spread in `build_report`. 
- Add unit tests in `tests/test_crypto_season.py` that mock `fetch_json`/`fetch_text` to cover CoinGecko parsing, CoinMarketCap primary endpoint and fallback scraping, and report classification. 
- Update `README.md` with usage (`python crypto_season.py` / `python crypto_season.py --json`) and test instructions (`python -m unittest discover -s tests`).

### Testing
- Ran unit tests with `python -m unittest discover -s tests` and they passed (`OK`, 4 tests ran). 
- Executing the live CLI (`python crypto_season.py --json`) failed in this environment due to outbound proxy restrictions resulting in `Tunnel connection failed: 403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936dad6a148323aed21137d3b8cc2e)